### PR TITLE
Put default config file content directly into memory

### DIFF
--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -23,12 +23,11 @@ class ConfigParser {
 
   validate() {
     if (!this.config) {
-      // Create the config file if it doesn't exist
-      fs.writeFile(this.staticSiteConfig.filePath, this.generateConfigFile(), (err) => {
+      core.info(`original raw configuration was invalid:\n${this.config}`)
+      core.info(`Generating a default configuration to start from...`)
 
-        // In case of a error throw err.
-        if (err) throw err;
-      })
+      // Update the `config` property with a default configuration file
+      this.config = this.generateConfigFile()
     }
   }
 


### PR DESCRIPTION
We ran into an issue with the Next.js starter workflow failing on a basic Next.js app created from an official example app (`blog-starter`) because it did not contain the expected configuration file:

https://github.com/paper-spa/starter-test-nextjs/runs/7119832261?check_suite_focus=true

```
Run paper-spa/configure-pages@main
Created pages site
Get the Base URL to the page with endpoint https://api.github.com/repos/paper-spa/starter-test-nextjs/pages
{"url":"https://api.github.com/repos/paper-spa/starter-test-nextjs/pages","status":null,"cname":null,"custom_404":false,"html_url":"https://paper-spa.github.io/starter-test-nextjs/","build_type":"workflow","source":{"branch":"main","path":"/"},"public":true,"protected_domain_state":null,"pending_domain_unverified_at":null,"https_enforced":true}
original configuration:
null
Error: Set pages path in the static site generator config failed
TypeError: Cannot read properties of undefined (reading 'properties')
    at ConfigParser.getPropertyModuleExport (/home/runner/work/_actions/paper-spa/configure-pages/main/webpack:/configure-pages/src/config-parser.js:101:1)
    at ConfigParser.parse (/home/runner/work/_actions/paper-spa/configure-pages/main/webpack:/configure-pages/src/config-parser.js:74:1)
    at setPagesPath (/home/runner/work/_actions/paper-spa/configure-pages/main/webpack:/configure-pages/src/set-pages-path.js:39:1)
    at getPagesBaseUrl (/home/runner/work/_actions/paper-spa/configure-pages/main/webpack:/configure-pages/src/get-pages-base-url.js:25:1)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at main (/home/runner/work/_actions/paper-spa/configure-pages/main/webpack:/configure-pages/src/index.js:13:1)
```

Although we have code in place that generates a default configuration file in that situation, we also did not update the `this.config` property to contain its contents, and our later parsing uses the `this.config` property directly rather than reading the file again (rightly so).

At first, I was going to update the asynchronous call to `fs.writeFile` to be synchronous with `fs.writeFileSync`, but then @YiMysty pointed out that we just use `this.config` directly, and so I took a different strategy of just putting that default configuration contents into memory instead since we aren't really gaining anything that I can tell by writing the default _unconfigured_ file out before reconfiguring it later. 🤷🏻‍♂️ 